### PR TITLE
Fix bug with # characters in .env 

### DIFF
--- a/.github/actions/build-node-zip/action.yml
+++ b/.github/actions/build-node-zip/action.yml
@@ -49,7 +49,7 @@ runs:
 
     # prepare static sites for config transformation upon later deployment
     - if: ${{ inputs.static-site }}
-      run: sed -n 's/\(${{ inputs.static-site-env-prefix }}_[A-Z0-9_]\+\)=\(.*\)/\1=#{\1}#/p' .env.sample > .env && cat .env
+      run: sed -n 's/\(${{ inputs.static-site-env-prefix }}_[A-Z0-9_]\+\)=\(.*\)/\1={{\1}}/p' .env.sample > .env && cat .env
       working-directory: ${{ inputs.working-directory }}
       shell: bash
       

--- a/.github/actions/node-deploy-cdk/action.yml
+++ b/.github/actions/node-deploy-cdk/action.yml
@@ -66,7 +66,7 @@ runs:
             IFS=':' read -r placeholder value <<< "$trimmed"
             if [ ! -z "$placeholder" ]
             then
-              replacements+="s/#{$placeholder}#/$(echo $value | sed -e 's/\\/\\\\/g; s/\//\\\//g; s/&/\\\&/g')/gI;"
+              replacements+="s/{{$placeholder}}/$(echo $value | sed -e 's/\\/\\\\/g; s/\//\\\//g; s/&/\\\&/g')/gI;"
             fi
           done
         fi

--- a/.github/workflows/node-build-zip.yml
+++ b/.github/workflows/node-build-zip.yml
@@ -57,7 +57,7 @@ jobs:
 
       # prepare static sites for config transformation upon later deployment
       - if: ${{ inputs.static-site }}
-        run: sed -n 's/\(${{ inputs.static-site-env-prefix }}_[A-Z0-9_]\+\)=\(.*\)/\1='#{\1}#'/p' .env.sample > .env && cat .env
+        run: sed -n 's/\(${{ inputs.static-site-env-prefix }}_[A-Z0-9_]\+\)=\(.*\)/\1={{\1}}/p' .env.sample > .env && cat .env
 
       # run npm ci preventing script access to npm auth token
       - run: npm ci --ignore-scripts

--- a/.github/workflows/node-build-zip.yml
+++ b/.github/workflows/node-build-zip.yml
@@ -57,7 +57,7 @@ jobs:
 
       # prepare static sites for config transformation upon later deployment
       - if: ${{ inputs.static-site }}
-        run: sed -n 's/\(${{ inputs.static-site-env-prefix }}_[A-Z0-9_]\+\)=\(.*\)/\1=#{\1}#/p' .env.sample > .env && cat .env
+        run: sed -n 's/\(${{ inputs.static-site-env-prefix }}_[A-Z0-9_]\+\)=\(.*\)/\1='#{\1}#'/p' .env.sample > .env && cat .env
 
       # run npm ci preventing script access to npm auth token
       - run: npm ci --ignore-scripts


### PR DESCRIPTION
I observed some strange behaviours when using this workflow for building astro website. Turns out strings wrapped in `#` are treated as comments and ignored by dotenv.
<img width="444" alt="image" src="https://user-images.githubusercontent.com/1898267/235837582-4376358e-8ce1-4a94-892a-d81356b01bfc.png">

This behaviour is not very consistent, for example, it works fine for `collective` (using VITE) but didn't work for `makerx-website` (using Astro). I think not using `#` all together will help us to avoid issues in the future