### PR TITLE
Add support for test environment variable in the test step of node-ci

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -24,6 +24,10 @@ on:
         required: false
         type: string
         default: npm run test --if-present
+      test-environment-variables:
+        required: false
+        type: string
+        default: '{}'
       audit-script:
         required: false
         type: string
@@ -101,6 +105,7 @@ jobs:
         run: ${{ inputs.pre-test-script }}
       - name: Test
         run: ${{ inputs.test-script }}
+        env: ${{ fromJson(inputs.test-environment-variables) }}
       - name: Audit
         run: ${{ inputs.audit-script }}
       - name: Build


### PR DESCRIPTION
GitHub Actions doesn't have an object input type.

I've used it this way:

```yml
ci-minter:
  name: Build and test minter
  uses: makerxstudio/shared-config/.github/workflows/node-ci.yml@fdd1e33b2c5d276f9389e0701db0242c5c2eb85f
  with:
    node-version: 16.x
    working-directory: ./minter
    pre-test-script: docker compose up --detach
    test-environment-variables: |
      {
        "ALGOD_SERVER": "http://localhost",
        "ALGOD_PORT": 4011,
        "ALGOD_TOKEN": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
        "KMD_PORT": 4012,
        "INDEXER_SERVER": "http://localhost",
        "INDEXER_PORT": 8990,
        "INDEXER_TOKEN": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
      }
```