### PR TITLE
Update `aws-actions/configure-aws-credentials`

### DIFF
--- a/.github/actions/node-deploy-cdk/action.yml
+++ b/.github/actions/node-deploy-cdk/action.yml
@@ -96,7 +96,7 @@ runs:
         node-version: ${{ inputs.node-version }}
 
     - name: Configure aws credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v3
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}


### PR DESCRIPTION
## What

Update `aws-actions/configure-aws-credentials` from v1 to v3.

## But, but... breaking changes?!

- [v2](https://github.com/aws-actions/configure-aws-credentials/blob/v3.0.1/CHANGELOG.md#200-2023-03-06) simpled bumped from Node.js 12 to Node.js 16 as GitHub Actions [doesn't support Node.js 12 anymore](https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/), so that'll remove warnings from logs.
- [v3](https://github.com/aws-actions/configure-aws-credentials/blob/v3.0.1/CHANGELOG.md#changes-to-existing-functionality-1) introduced a couple changes:
   1. Default session duration is now 1 hour in all cases (from 6 hours in some cases) &mdash; we can adjust with the `role-duration-seconds` input if needed.
   1. Account ID will not be masked by default in logs &mdash; we can use `mask-aws-account-id` if we want to keep it masked.