### PR TITLE
[docker-build] Add input to control whether the artifact is uploaded

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -16,6 +16,13 @@ inputs:
   npm-token:
     description: NPM token to fetch private packages
     required: true
+  upload-artifact:
+    description: |
+      Whether to upload the artifact to GitHub Actions.
+      Useful to disable for PR runs.
+      Set to anything else than 'true' to disable.
+    required: false
+    default: 'true'
 
 # Why not use the official docker GitHub actions?
 # Well, they only support buildx, which only supports BuildKit, which doesn't support verifying the authenticity
@@ -44,6 +51,7 @@ runs:
       shell: bash
 
     - name: Upload artifact
+      if: inputs.upload-artifact == 'true'
       uses: actions/upload-artifact@v3
       with:
         name: ${{ inputs.image-label }}-docker-image


### PR DESCRIPTION
## What

Adds an input to the `docker-build` to control whether the artifact is uploaded.
No breaking changes, the default value is `'true'` (yes, a string, thank you), which means the artifact will be uploaded.

## Why

We usually don't need to publish Docker images artifacts for PR runs, but it's still useful to know that it worked.

Also, I've seen a rough copy of this file in another project, where the only difference was to control if the artifact is uploaded.