### PR TITLE
feat: Make node18 the default

### DIFF
--- a/.github/actions/build-node-zip/action.yml
+++ b/.github/actions/build-node-zip/action.yml
@@ -5,7 +5,7 @@ inputs:
   node-version:
     description: Node version
     required: false
-    default: 16.x
+    default: 18.x
   working-directory:
     description: Working directory
     required: false

--- a/.github/actions/build-node/action.yml
+++ b/.github/actions/build-node/action.yml
@@ -5,7 +5,7 @@ inputs:
   node-version:
     description: Node version
     required: false
-    default: 16.x
+    default: 18.x
   working-directory:
     description: Working directory
     required: false

--- a/.github/actions/node-deploy-cdk/action.yml
+++ b/.github/actions/node-deploy-cdk/action.yml
@@ -4,7 +4,7 @@ inputs:
   node-version:
     description: Node.js version to use
     required: false
-    default: 16.x
+    default: 18.x
   aws-access-key-id:
     description: AWS Access Key ID
     required: true

--- a/.github/workflows/node-build-zip.yml
+++ b/.github/workflows/node-build-zip.yml
@@ -4,7 +4,7 @@ on:
       node-version:
         required: false
         type: string
-        default: 16.x
+        default: 18.x
       working-directory:
         required: false
         type: string

--- a/.github/workflows/node-build.yml
+++ b/.github/workflows/node-build.yml
@@ -4,7 +4,7 @@ on:
       node-version:
         required: false
         type: string
-        default: 16.x
+        default: 18.x
       working-directory:
         required: false
         type: string

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -4,7 +4,7 @@ on:
       node-version:
         required: false
         type: string
-        default: 16.x
+        default: 18.x
       working-directory:
         required: false
         type: string

--- a/.github/workflows/node-deploy-azure-web-app.yml
+++ b/.github/workflows/node-deploy-azure-web-app.yml
@@ -5,7 +5,7 @@ on:
       node-version:
         required: false
         type: string
-        default: 16.x
+        default: 18.x
       web-app-name:
         required: true
         type: string

--- a/.github/workflows/node-publish-internal.yml
+++ b/.github/workflows/node-publish-internal.yml
@@ -4,7 +4,7 @@ on:
       node-version:
         required: false
         type: string
-        default: 16.x
+        default: 18.x
       package-path:
         required: false
         type: string

--- a/.github/workflows/node-publish-public.yml
+++ b/.github/workflows/node-publish-public.yml
@@ -4,7 +4,7 @@ on:
       node-version:
         required: false
         type: string
-        default: 16.x
+        default: 18.x
       package-path:
         required: false
         type: string


### PR DESCRIPTION
The maintenance window for Node 16 is ending mid September, so it makes sense to update to 18.

**BREAKING CHANGE:** Node18 will now be default, which may result in build pipeline failures.
If you want to pin to node16, supply `node-version: 16.x` when using the action or workflow, for example:
```
uses: makerxstudio/shared-config/.github/workflows/node-ci.yml@main
with:
   node-version: 16.x
```

Similarly, if you'd like to test your builds ahead of time you can use the above and set the value to `node-version: 18.x`

Assuming everyone is ok with this, we will aim to **merge this on Wednesday 2023-09-13**.