### PR TITLE
Update `actions/upload-artifact` and `actions/download-artifact` to v4

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -52,7 +52,7 @@ runs:
 
     - name: Upload artifact
       if: inputs.upload-artifact == 'true'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.image-label }}-docker-image
         path: ${{ inputs.working-directory }}/${{ inputs.image-label }}-docker-image.zip

--- a/.github/actions/build-node-zip/action.yml
+++ b/.github/actions/build-node-zip/action.yml
@@ -84,7 +84,7 @@ runs:
       shell: bash
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifact-name }}
         path: ${{ inputs.working-directory }}/${{ inputs.artifact-name }}.zip

--- a/.github/actions/build-node/action.yml
+++ b/.github/actions/build-node/action.yml
@@ -67,7 +67,7 @@ runs:
         NODE_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifact-name }}
         path: ${{ inputs.working-directory }}/${{ inputs.build-path }}

--- a/.github/actions/node-deploy-cdk/action.yml
+++ b/.github/actions/node-deploy-cdk/action.yml
@@ -40,7 +40,7 @@ runs:
   using: composite
   steps:
     - name: Download artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         path: artifacts
 

--- a/.github/workflows/node-build-zip.yml
+++ b/.github/workflows/node-build-zip.yml
@@ -86,7 +86,7 @@ jobs:
         run: pushd ${{ inputs.build-path }}; zip -q -r ../${{ inputs.artifact-name }}.zip *
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.artifact-name }}
           path: ${{ inputs.working-directory }}/${{ inputs.artifact-name }}.zip

--- a/.github/workflows/node-build.yml
+++ b/.github/workflows/node-build.yml
@@ -71,7 +71,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.npm-auth-token || secrets.GITHUB_TOKEN }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.artifact-name }}
           path: ${{ inputs.working-directory }}/${{ inputs.build-path }}

--- a/.github/workflows/node-deploy-azure-web-app.yml
+++ b/.github/workflows/node-deploy-azure-web-app.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact-name }}
 


### PR DESCRIPTION
> [!CAUTION]
>
> DO NOT MERGE THIS PR JUST YET.
>
> We need to update all workflows in the organisation to update the versions of the `actions/upload-artifact` and `actions/download-artifact` they use to be in line with this change since v3 and v4 aren't compatible.

See:

- Announcement: <https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/>.
- Slack thread: <https://makerx-workspace.slack.com/archives/C02NAS8E52P/p1706000717344339>.