### PR TITLE
Always output test results

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -122,7 +122,7 @@ jobs:
         #Requires permissions.checks: write
       - name: Publish test results
         if: ${{ always() && inputs.output-test-results }}
-        uses: phoenix-actions/test-reporting@v10
+        uses: phoenix-actions/test-reporting@v15
         with:
           name: Test results
           path: ${{ inputs.test-results-file-pattern }}

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -121,8 +121,8 @@ jobs:
       
         #Requires permissions.checks: write
       - name: Publish test results
-        if: ${{ inputs.output-test-results }}
-        uses: phoenix-actions/test-reporting@v10        
+        if: ${{ always() && inputs.output-test-results }}
+        uses: phoenix-actions/test-reporting@v10
         with:
           name: Test results
           path: ${{ inputs.test-results-file-pattern }}
@@ -139,5 +139,3 @@ jobs:
         # CDK infrastructure build calls npm ci on /infrastructure/build, which may fail without NODE_AUTH_TOKEN
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm-auth-token || secrets.GITHUB_TOKEN }}
-          
-


### PR DESCRIPTION
## What

This updates `node-ci` so that we publish test results whether the workflow runs succeeds or fails.

I had to update the action version to work around an issue where it would fail because of an [stackTrace.split is not a function error](https://github.com/phoenix-actions/test-reporting/issues?q=is%3Aissue%20state%3Aclosed%20stackTrace.split%20is%20not%20a%20function), which seems to have been resolved in recent versions.

### Before

![image](https://github.com/user-attachments/assets/ca4348c7-f263-47ed-b7bd-6ee9d7962bce)

### After

![image](https://github.com/user-attachments/assets/00a7e6c0-92bb-40ed-821b-a78b919c3644)

![image](https://github.com/user-attachments/assets/fec41c2f-a46b-40d2-a82f-308a672e346f)
