### PR TITLE
fix: correct artifact extraction glob for download-artifact v8

### DIFF
--- a/.github/actions/node-deploy-cdk/action.yml
+++ b/.github/actions/node-deploy-cdk/action.yml
@@ -53,12 +53,14 @@ runs:
 
     - name: Extract artifact archives
       run: |
-        for zip in artifacts/*.zip; do
+        for zip in artifacts/*/*.zip; do
           [ -f "$zip" ] || continue
-          name=$(basename "$zip" .zip)
-          mkdir -p "artifacts/$name"
-          unzip -q "$zip" -d "artifacts/$name"
+          dir=$(dirname "$zip")
+          tmp=$(mktemp -d)
+          unzip -q "$zip" -d "$tmp"
           rm "$zip"
+          mv "$tmp"/* "$dir/"
+          rm -rf "$tmp"
         done
       shell: bash
 

--- a/.github/actions/prepare-artifact/action.yml
+++ b/.github/actions/prepare-artifact/action.yml
@@ -42,12 +42,14 @@ runs:
 
     - name: Extract artifact archives
       run: |
-        for zip in ${{ inputs.artifacts-path }}/*.zip; do
+        for zip in ${{ inputs.artifacts-path }}/*/*.zip; do
           [ -f "$zip" ] || continue
-          name=$(basename "$zip" .zip)
-          mkdir -p "${{ inputs.artifacts-path }}/$name"
-          unzip -q "$zip" -d "${{ inputs.artifacts-path }}/$name"
+          dir=$(dirname "$zip")
+          tmp=$(mktemp -d)
+          unzip -q "$zip" -d "$tmp"
           rm "$zip"
+          mv "$tmp"/* "$dir/"
+          rm -rf "$tmp"
         done
       shell: bash
 


### PR DESCRIPTION
## Summary

- Fixes the `Extract artifact archives` step in both `node-deploy-cdk` and `prepare-artifact` actions
- The glob `artifacts/*.zip` didn't match the actual download-artifact v8 layout (`artifacts/<name>/<name>.zip`), making the extraction a no-op
- The infrastructure unzip step was extracting the outer artifact container instead of the inner build zip, causing `npm rebuild` to fail with `ENOENT: no such file or directory, open 'infrastructure/package.json'`
- Changed glob to `artifacts/*/*.zip` and extracts via a temp directory to safely handle the naming collision between the container zip and its inner content

## Test plan

- [ ] Deploy a CDK project using the `node-deploy-cdk` action and verify the infrastructure artifact is correctly extracted and `npm rebuild` succeeds
- [ ] Verify app artifacts are also correctly extracted and unzipped in the `Unzip app artifacts` step
- [ ] Test the `prepare-artifact` action with multiple artifacts to confirm the same fix works there