### PR TITLE
Add tag input to node-trusted-publish workflow

### DIFF
--- a/.github/workflows/node-trusted-publish.yml
+++ b/.github/workflows/node-trusted-publish.yml
@@ -13,6 +13,10 @@ on:
         required: false
         type: string
         default: 'restricted' # 'public' or 'restricted'
+      tag:
+        required: false
+        type: string
+        default: ''
 
 jobs:
   node-publish:
@@ -53,3 +57,4 @@ jobs:
         with:
           package: ${{ inputs.package-path }}
           access: ${{ inputs.access }}
+          tag: ${{ inputs.tag }}


### PR DESCRIPTION
So that we can publish pre-release versions etc, which we cannot currently do..

```json
{
  "name": "@makerx/node-winston",
  "version": "2.0.0-beta.0",
```

```yaml
  publish:
    needs: ci
    uses: makerxstudio/shared-config/.github/workflows/node-trusted-publish.yml@main
    with:
      access: public
      tag: beta
```

<img width="959" height="528" alt="image" src="https://github.com/user-attachments/assets/d62fefbf-8d6c-45c3-83df-35cdfbb27faf" />
