### PR TITLE
feat(deploy-bicep): expose bicep-version input

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -46,7 +46,7 @@ runs:
 
     - name: Set up Docker Buildx
       if: inputs.use-buildkit == 'true'
-      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
     - name: Build
       shell: bash
@@ -78,7 +78,7 @@ runs:
 
     - name: Upload artifact
       if: inputs.upload-artifact == 'true'
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.image-label }}-docker-image
         path: ${{ inputs.working-directory }}/${{ inputs.image-label }}-docker-image.zip

--- a/.github/actions/build-node-zip/action.yml
+++ b/.github/actions/build-node-zip/action.yml
@@ -33,13 +33,13 @@ runs:
 
   steps:
     - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
 
     # setup node + private repo access
     - name: Use Node.js ${{ inputs.node-version }}
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ inputs.node-version }}
         registry-url: 'https://npm.pkg.github.com'
@@ -84,7 +84,7 @@ runs:
       shell: bash
 
     - name: Upload artifact
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.artifact-name }}
         path: ${{ inputs.working-directory }}/${{ inputs.artifact-name }}.zip

--- a/.github/actions/build-node/action.yml
+++ b/.github/actions/build-node/action.yml
@@ -27,13 +27,13 @@ runs:
 
   steps:
     - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
 
     # setup node + private repo access
     - name: Use Node.js ${{ inputs.node-version }}
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ inputs.node-version }}
         registry-url: 'https://npm.pkg.github.com'
@@ -67,7 +67,7 @@ runs:
         NODE_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
 
     - name: Upload artifact
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.artifact-name }}
         path: ${{ inputs.working-directory }}/${{ inputs.build-path }}

--- a/.github/actions/deploy-bicep/action.yml
+++ b/.github/actions/deploy-bicep/action.yml
@@ -50,6 +50,9 @@ inputs:
     description: 'Whether to display template outputs; e.g. set to false to avoid ouputting secure outputs'
     required: false
     default: 'true'
+  bicep-version:
+    description: 'Bicep CLI version to install (e.g. ''0.43.1''). If unset, azure/bicep-deploy resolves https://downloads.bicep.azure.com/releases/latest at runtime, which is non-deterministic across runs.'
+    required: false
 outputs:
   deploymentOutputs:
     description: 'Outputs from the deployment as JSON string'
@@ -72,6 +75,7 @@ runs:
         template-file: ${{ inputs.template-file }}
         parameters-file: ${{ inputs.parameters-file }}
         parameters: ${{ inputs.parameters-json }}
+        bicep-version: ${{ inputs.bicep-version }}
 
     - name: Generate Azure Portal deployment link
       id: generate-link
@@ -95,6 +99,7 @@ runs:
         template-file: ${{ inputs.template-file }}
         parameters-file: ${{ inputs.parameters-file }}
         parameters: ${{ inputs.parameters-json }}
+        bicep-version: ${{ inputs.bicep-version }}
 
     - name: Output deployment outputs
       if: ${{ inputs.display-outputs == 'true' }}

--- a/.github/actions/deploy-bicep/action.yml
+++ b/.github/actions/deploy-bicep/action.yml
@@ -61,7 +61,7 @@ runs:
   using: 'composite'
   steps:
     - name: Run what-if for Bicep template
-      uses: azure/bicep-deploy@66910e9c5c7733c33a1cd605030d02234b3bc4ed # v2
+      uses: azure/bicep-deploy@66910e9c5c7733c33a1cd605030d02234b3bc4ed # v2.3.0
       if: ${{ inputs.run-what-if == 'true' }}
       with:
         type: deployment
@@ -87,7 +87,7 @@ runs:
 
     - name: Deploy Bicep template
       id: deploy-template
-      uses: azure/bicep-deploy@66910e9c5c7733c33a1cd605030d02234b3bc4ed # v2
+      uses: azure/bicep-deploy@66910e9c5c7733c33a1cd605030d02234b3bc4ed # v2.3.0
       with:
         type: deployment
         operation: create

--- a/.github/actions/node-deploy-cdk/action.yml
+++ b/.github/actions/node-deploy-cdk/action.yml
@@ -46,7 +46,7 @@ runs:
   using: composite
   steps:
     - name: Download artifacts
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         path: artifacts
         skip-decompress: true
@@ -111,7 +111,7 @@ runs:
       shell: bash
 
     - name: Use Node.js ${{ inputs.node-version }}
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ inputs.node-version }}
 

--- a/.github/actions/prepare-artifact/action.yml
+++ b/.github/actions/prepare-artifact/action.yml
@@ -34,7 +34,7 @@ runs:
   using: composite
   steps:
     - name: Download artifacts
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         path: ${{ inputs.artifacts-path }}
         pattern: ${{ inputs.artifact-pattern }}

--- a/.github/workflows/ensure-sha-pinned-actions.yml
+++ b/.github/workflows/ensure-sha-pinned-actions.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Ensure SHA pinned actions
         id: pinned-actions

--- a/.github/workflows/node-build-zip.yml
+++ b/.github/workflows/node-build-zip.yml
@@ -52,13 +52,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       # setup node + private repo access
       - name: Use Node.js ${{ inputs.node-version }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
           registry-url: "https://npm.pkg.github.com"
@@ -94,7 +94,7 @@ jobs:
         run: pushd ${{ inputs.build-path }}; zip -q -r ../${{ inputs.artifact-name }}.zip *
 
       - name: Upload artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.artifact-name }}
           path: ${{ inputs.working-directory }}/${{ inputs.artifact-name }}.zip

--- a/.github/workflows/node-build.yml
+++ b/.github/workflows/node-build.yml
@@ -36,13 +36,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       # setup node + private repo access
       - name: Use Node.js ${{ inputs.node-version }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
           registry-url: 'https://npm.pkg.github.com'
@@ -71,7 +71,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.npm-auth-token || secrets.GITHUB_TOKEN }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.artifact-name }}
           path: ${{ inputs.working-directory }}/${{ inputs.build-path }}

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -90,13 +90,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       # setup node + private repo access
       - name: Use Node.js ${{ inputs.node-version }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
           registry-url: 'https://npm.pkg.github.com'
@@ -174,7 +174,7 @@ jobs:
 
       - name: Upload SBOM
         if: ${{ inputs.generate-sbom }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.sbom-artifact-name }}
           path: ${{ inputs.working-directory }}/${{ inputs.sbom-artifact-name }}.${{ inputs.sbom-format == 'spdx' && 'spdx.json' || 'cdx.json' }}

--- a/.github/workflows/node-deploy-azure-web-app.yml
+++ b/.github/workflows/node-deploy-azure-web-app.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.artifact-name }}
           path: artifact-download
@@ -55,7 +55,7 @@ jobs:
 
       - name: 'Deploy to Azure WebApp'
         id: deploy-to-webapp
-        uses: azure/webapps-deploy@02a81bead70021f5284939794bcec79c271ab383 # v3
+        uses: azure/webapps-deploy@02a81bead70021f5284939794bcec79c271ab383 # v3.0.8
         with:
           app-name: ${{ env.AZURE_WEBAPP_NAME }}
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}

--- a/.github/workflows/node-pnpm-build-zip.yml
+++ b/.github/workflows/node-pnpm-build-zip.yml
@@ -59,19 +59,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
         with:
           version: ${{ inputs.pnpm-version }}
           standalone: true
 
       - name: Use Node.js ${{ inputs.node-version }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
           cache: "pnpm"
@@ -104,7 +104,7 @@ jobs:
       
       # working dir doesn't apply to this, so we are explicit here
       - name: Upload artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.artifact-name }}
           path: ${{ inputs.working-directory }}/${{ inputs.artifact-name }}.zip

--- a/.github/workflows/node-publish-internal.yml
+++ b/.github/workflows/node-publish-internal.yml
@@ -25,13 +25,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       # setup node + private repo access
       - name: Use Node.js ${{ inputs.node-version }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
           registry-url: 'https://npm.pkg.github.com'
@@ -49,7 +49,7 @@ jobs:
       - run: npm run build
 
       - name: Publish (if version has been updated)
-        uses: JS-DevTools/npm-publish@0fd2f4369c5d6bcfcde6091a7c527d810b9b5c3f # v4
+        uses: JS-DevTools/npm-publish@0fd2f4369c5d6bcfcde6091a7c527d810b9b5c3f # v4.1.5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           package: ${{ inputs.package-path }}

--- a/.github/workflows/node-publish-public.yml
+++ b/.github/workflows/node-publish-public.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Use Node.js ${{ inputs.node-version }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
           cache: 'npm'
@@ -36,7 +36,7 @@ jobs:
       - run: npm run build
 
       - name: Publish (if version has been updated)
-        uses: JS-DevTools/npm-publish@0fd2f4369c5d6bcfcde6091a7c527d810b9b5c3f # v4
+        uses: JS-DevTools/npm-publish@0fd2f4369c5d6bcfcde6091a7c527d810b9b5c3f # v4.1.5
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: ${{ inputs.package-path }}

--- a/.github/workflows/node-trusted-publish.yml
+++ b/.github/workflows/node-trusted-publish.yml
@@ -26,12 +26,12 @@ jobs:
       id-token: write  # Required for OIDC
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Use Node.js ${{ inputs.node-version }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
           cache: 'npm'
@@ -53,7 +53,7 @@ jobs:
       - run: npm run build
 
       - name: Publish (if version has been updated)
-        uses: JS-DevTools/npm-publish@0fd2f4369c5d6bcfcde6091a7c527d810b9b5c3f # v4
+        uses: JS-DevTools/npm-publish@0fd2f4369c5d6bcfcde6091a7c527d810b9b5c3f # v4.1.5
         with:
           package: ${{ inputs.package-path }}
           access: ${{ inputs.access }}

--- a/.github/workflows/python-uv-build-zip.yml
+++ b/.github/workflows/python-uv-build-zip.yml
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -94,7 +94,7 @@ jobs:
           zip -q -r ${{ runner.temp }}/${{ inputs.artifact-name }}.zip ${{ inputs.build-globs }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.artifact-name }}
           path: ${{ runner.temp }}/${{ inputs.artifact-name }}.zip

--- a/.github/workflows/python-uv-ci.yml
+++ b/.github/workflows/python-uv-ci.yml
@@ -126,7 +126,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -215,7 +215,7 @@ jobs:
 
       - name: Publish coverage
         if: ${{ inputs.publish-coverage-path }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage
           path: ${{ inputs.publish-coverage-path }}
@@ -227,7 +227,7 @@ jobs:
         # Requires permissions.checks: write
       - name: Surface failing tests
         if: inputs.output-test-results && inputs.run-tests
-        uses: pmeier/pytest-results-action@fdc7f18d9934e38aca411ca9557e6577bd25ca9c
+        uses: pmeier/pytest-results-action@fdc7f18d9934e38aca411ca9557e6577bd25ca9c # v0.9.0
         with:
           path: ${{ inputs.test-results-file-pattern }}
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
               id: release
               with:
                   release-type: simple
-            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
             - name: tag major and minor versions
               if: ${{ steps.release.outputs.release_created }}
               run: |


### PR DESCRIPTION
## Summary

Adds an optional `bicep-version` input on the `deploy-bicep` composite action, forwarded through to both the what-if and deploy `azure/bicep-deploy` steps.

When unset, behaviour is unchanged: `bicep-deploy` resolves [`https://downloads.bicep.azure.com/releases/latest`](https://downloads.bicep.azure.com/releases/latest) at runtime, which is non-deterministic per run and silently exposes consumers to new Bicep releases.

## Why

[Azure/bicep#19600](https://github.com/Azure/bicep/issues/19600) — newer Bicep versions may stop emitting the 2.1-experimental ARM language version that the `@retryOn` decorator relies on. Consumers using `@retryOn` need to pin to a known-good Bicep version (e.g. 0.43.1). Today there's no way to pin through this wrapper.

## Test plan

- [ ] CI passes