### PR TITLE
feat(ci): parameterize reusable workflow runners

### DIFF
--- a/.github/workflows/ensure-sha-pinned-actions.yml
+++ b/.github/workflows/ensure-sha-pinned-actions.yml
@@ -12,6 +12,10 @@ on:
       - '.github/actions/**'
   workflow_call:
     inputs:
+      runner:
+        required: false
+        type: string
+        default: ubuntu-latest
       allowlist:
         description: 'Newline-separated list of allowed owners or repositories. Optional.'
         type: string
@@ -45,7 +49,7 @@ permissions:
 jobs:
   ensure-sha-pinned:
     name: Ensure SHA Pinned Actions
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ensure-sha-pinned-actions.yml
+++ b/.github/workflows/ensure-sha-pinned-actions.yml
@@ -12,7 +12,7 @@ on:
       - '.github/actions/**'
   workflow_call:
     inputs:
-      runner:
+      runs-on:
         required: false
         type: string
         default: ubuntu-latest
@@ -49,7 +49,7 @@ permissions:
 jobs:
   ensure-sha-pinned:
     name: Ensure SHA Pinned Actions
-    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runs-on || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/github_zendesk_issue_closed.yml
+++ b/.github/workflows/github_zendesk_issue_closed.yml
@@ -2,7 +2,7 @@ name: Solve Zendesk ticket
 on:
   workflow_call:
     inputs:
-      runner:
+      runs-on:
         required: false
         type: string
         default: ubuntu-latest
@@ -22,7 +22,7 @@ jobs:
   solve-ticket:
     name: Solve Zendesk ticket
     if: ${{ contains(github.event.issue.labels.*.name, inputs.ISSUE_LABEL) }}
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runs-on }}
     steps:
       - env:
           TENANT_NAME: ${{ inputs.ZENDESK_TENANT_NAME }}

--- a/.github/workflows/github_zendesk_issue_closed.yml
+++ b/.github/workflows/github_zendesk_issue_closed.yml
@@ -2,6 +2,10 @@ name: Solve Zendesk ticket
 on:
   workflow_call:
     inputs:
+      runner:
+        required: false
+        type: string
+        default: ubuntu-latest
       ZENDESK_TENANT_NAME:
         description: 'The zendesk tenant name, can be found in the URL, for example https://my-subdomain.zendesk.com/'
         required: true
@@ -18,7 +22,7 @@ jobs:
   solve-ticket:
     name: Solve Zendesk ticket
     if: ${{ contains(github.event.issue.labels.*.name, inputs.ISSUE_LABEL) }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     steps:
       - env:
           TENANT_NAME: ${{ inputs.ZENDESK_TENANT_NAME }}

--- a/.github/workflows/github_zendesk_issue_commented.yml
+++ b/.github/workflows/github_zendesk_issue_commented.yml
@@ -2,6 +2,10 @@ name: Add comment to Zendesk ticket
 on:
   workflow_call:
     inputs:
+      runner:
+        required: false
+        type: string
+        default: ubuntu-latest
       ZENDESK_TENANT_NAME:
         description: 'The zendesk tenant name, can be found in the URL, for example https://my-subdomain.zendesk.com/'
         required: true
@@ -18,7 +22,7 @@ jobs:
   add-ticket-comment:
     name: Add comment to Zendesk ticket
     if: ${{ !github.event.issue.pull_request && contains(github.event.issue.labels.*.name, inputs.ISSUE_LABEL) }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     steps:
       - id: add-ticket-comment
         env:

--- a/.github/workflows/github_zendesk_issue_commented.yml
+++ b/.github/workflows/github_zendesk_issue_commented.yml
@@ -2,7 +2,7 @@ name: Add comment to Zendesk ticket
 on:
   workflow_call:
     inputs:
-      runner:
+      runs-on:
         required: false
         type: string
         default: ubuntu-latest
@@ -22,7 +22,7 @@ jobs:
   add-ticket-comment:
     name: Add comment to Zendesk ticket
     if: ${{ !github.event.issue.pull_request && contains(github.event.issue.labels.*.name, inputs.ISSUE_LABEL) }}
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runs-on }}
     steps:
       - id: add-ticket-comment
         env:

--- a/.github/workflows/github_zendesk_issue_labelled.yml
+++ b/.github/workflows/github_zendesk_issue_labelled.yml
@@ -2,6 +2,10 @@ name: Create Zendesk ticket
 on:
   workflow_call:
     inputs:
+      runner:
+        required: false
+        type: string
+        default: ubuntu-latest
       ZENDESK_TENANT_NAME:
         description: 'The zendesk tenant name, can be found in the URL, for example https://my-subdomain.zendesk.com/'
         required: true
@@ -18,7 +22,7 @@ jobs:
   create-ticket:
     name: Create Zendesk ticket
     if: github.event.label.name == inputs.ISSUE_LABEL
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     steps:
       - env:
           TENANT_NAME: ${{ inputs.ZENDESK_TENANT_NAME }}

--- a/.github/workflows/github_zendesk_issue_labelled.yml
+++ b/.github/workflows/github_zendesk_issue_labelled.yml
@@ -2,7 +2,7 @@ name: Create Zendesk ticket
 on:
   workflow_call:
     inputs:
-      runner:
+      runs-on:
         required: false
         type: string
         default: ubuntu-latest
@@ -22,7 +22,7 @@ jobs:
   create-ticket:
     name: Create Zendesk ticket
     if: github.event.label.name == inputs.ISSUE_LABEL
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runs-on }}
     steps:
       - env:
           TENANT_NAME: ${{ inputs.ZENDESK_TENANT_NAME }}

--- a/.github/workflows/node-build-zip.yml
+++ b/.github/workflows/node-build-zip.yml
@@ -1,6 +1,10 @@
 on:
   workflow_call:
     inputs:
+      runner:
+        required: false
+        type: string
+        default: ubuntu-latest
       node-version:
         required: false
         type: string
@@ -43,7 +47,7 @@ on:
 
 jobs:
   build-zip:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
 
     defaults:
       run:

--- a/.github/workflows/node-build-zip.yml
+++ b/.github/workflows/node-build-zip.yml
@@ -1,7 +1,7 @@
 on:
   workflow_call:
     inputs:
-      runner:
+      runs-on:
         required: false
         type: string
         default: ubuntu-latest
@@ -47,7 +47,7 @@ on:
 
 jobs:
   build-zip:
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runs-on }}
 
     defaults:
       run:

--- a/.github/workflows/node-build.yml
+++ b/.github/workflows/node-build.yml
@@ -1,6 +1,10 @@
 on:
   workflow_call:
     inputs:
+      runner:
+        required: false
+        type: string
+        default: ubuntu-latest
       node-version:
         required: false
         type: string
@@ -27,7 +31,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
 
     defaults:
       run:

--- a/.github/workflows/node-build.yml
+++ b/.github/workflows/node-build.yml
@@ -1,7 +1,7 @@
 on:
   workflow_call:
     inputs:
-      runner:
+      runs-on:
         required: false
         type: string
         default: ubuntu-latest
@@ -31,7 +31,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runs-on }}
 
     defaults:
       run:

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -1,6 +1,10 @@
 on:
   workflow_call:
     inputs:
+      runner:
+        required: false
+        type: string
+        default: ubuntu-latest
       node-version:
         required: false
         type: string
@@ -81,7 +85,7 @@ on:
 
 jobs:
   node-ci:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
 
     defaults:
       run:

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -1,7 +1,7 @@
 on:
   workflow_call:
     inputs:
-      runner:
+      runs-on:
         required: false
         type: string
         default: ubuntu-latest
@@ -85,7 +85,7 @@ on:
 
 jobs:
   node-ci:
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runs-on }}
 
     defaults:
       run:

--- a/.github/workflows/node-deploy-azure-web-app.yml
+++ b/.github/workflows/node-deploy-azure-web-app.yml
@@ -2,6 +2,10 @@ name: deploy-web-app
 on:
   workflow_call:
     inputs:
+      runner:
+        required: false
+        type: string
+        default: ubuntu-latest
       node-version:
         required: false
         type: string
@@ -34,7 +38,7 @@ jobs:
     name: ${{ inputs.environment-name }}
     permissions:
       contents: none
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     environment:
       name: ${{ inputs.environment-name }}
       url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}

--- a/.github/workflows/node-deploy-azure-web-app.yml
+++ b/.github/workflows/node-deploy-azure-web-app.yml
@@ -2,7 +2,7 @@ name: deploy-web-app
 on:
   workflow_call:
     inputs:
-      runner:
+      runs-on:
         required: false
         type: string
         default: ubuntu-latest
@@ -38,7 +38,7 @@ jobs:
     name: ${{ inputs.environment-name }}
     permissions:
       contents: none
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runs-on }}
     environment:
       name: ${{ inputs.environment-name }}
       url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}

--- a/.github/workflows/node-pnpm-build-zip.yml
+++ b/.github/workflows/node-pnpm-build-zip.yml
@@ -1,6 +1,10 @@
 on:
   workflow_call:
     inputs:
+      runner:
+        required: false
+        type: string
+        default: ubuntu-latest
       pnpm-version:
         required: false
         type: string
@@ -50,7 +54,7 @@ permissions:
 
 jobs:
   build-zip:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
 
     defaults:
       run:

--- a/.github/workflows/node-pnpm-build-zip.yml
+++ b/.github/workflows/node-pnpm-build-zip.yml
@@ -1,7 +1,7 @@
 on:
   workflow_call:
     inputs:
-      runner:
+      runs-on:
         required: false
         type: string
         default: ubuntu-latest
@@ -54,7 +54,7 @@ permissions:
 
 jobs:
   build-zip:
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runs-on }}
 
     defaults:
       run:

--- a/.github/workflows/node-publish-internal.yml
+++ b/.github/workflows/node-publish-internal.yml
@@ -1,7 +1,7 @@
 on:
   workflow_call:
     inputs:
-      runner:
+      runs-on:
         required: false
         type: string
         default: ubuntu-latest
@@ -20,7 +20,7 @@ on:
 
 jobs:
   node-publish-internal:
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runs-on }}
 
     defaults:
       run:

--- a/.github/workflows/node-publish-internal.yml
+++ b/.github/workflows/node-publish-internal.yml
@@ -1,6 +1,10 @@
 on:
   workflow_call:
     inputs:
+      runner:
+        required: false
+        type: string
+        default: ubuntu-latest
       node-version:
         required: false
         type: string
@@ -16,7 +20,7 @@ on:
 
 jobs:
   node-publish-internal:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
 
     defaults:
       run:

--- a/.github/workflows/node-publish-public.yml
+++ b/.github/workflows/node-publish-public.yml
@@ -1,7 +1,7 @@
 on:
   workflow_call:
     inputs:
-      runner:
+      runs-on:
         required: false
         type: string
         default: ubuntu-latest
@@ -20,7 +20,7 @@ on:
 
 jobs:
   node-publish-public:
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/node-publish-public.yml
+++ b/.github/workflows/node-publish-public.yml
@@ -1,6 +1,10 @@
 on:
   workflow_call:
     inputs:
+      runner:
+        required: false
+        type: string
+        default: ubuntu-latest
       node-version:
         required: false
         type: string
@@ -16,7 +20,7 @@ on:
 
 jobs:
   node-publish-public:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/node-trusted-publish.yml
+++ b/.github/workflows/node-trusted-publish.yml
@@ -1,6 +1,10 @@
 on:
   workflow_call:
     inputs:
+      runner:
+        required: false
+        type: string
+        default: ubuntu-latest
       node-version:
         required: false
         type: string
@@ -24,7 +28,7 @@ on:
 
 jobs:
   node-publish:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     permissions:
       contents: read
       id-token: write  # Required for OIDC

--- a/.github/workflows/node-trusted-publish.yml
+++ b/.github/workflows/node-trusted-publish.yml
@@ -1,7 +1,7 @@
 on:
   workflow_call:
     inputs:
-      runner:
+      runs-on:
         required: false
         type: string
         default: ubuntu-latest
@@ -28,7 +28,7 @@ on:
 
 jobs:
   node-publish:
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runs-on }}
     permissions:
       contents: read
       id-token: write  # Required for OIDC

--- a/.github/workflows/python-uv-build-zip.yml
+++ b/.github/workflows/python-uv-build-zip.yml
@@ -1,6 +1,10 @@
 on:
   workflow_call:
     inputs:
+      runner:
+        required: false
+        type: string
+        default: ubuntu-latest
       python-version:
         required: false
         type: string
@@ -49,7 +53,7 @@ on:
 
 jobs:
   python-ci:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
 
     defaults:
       run:

--- a/.github/workflows/python-uv-build-zip.yml
+++ b/.github/workflows/python-uv-build-zip.yml
@@ -1,7 +1,7 @@
 on:
   workflow_call:
     inputs:
-      runner:
+      runs-on:
         required: false
         type: string
         default: ubuntu-latest
@@ -53,7 +53,7 @@ on:
 
 jobs:
   python-ci:
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runs-on }}
 
     defaults:
       run:

--- a/.github/workflows/python-uv-ci.yml
+++ b/.github/workflows/python-uv-ci.yml
@@ -1,6 +1,10 @@
 on:
   workflow_call:
     inputs:
+      runner:
+        required: false
+        type: string
+        default: ubuntu-latest
       python-version:
         required: false
         type: string
@@ -117,7 +121,7 @@ on:
 
 jobs:
   python-ci:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
 
     defaults:
       run:

--- a/.github/workflows/python-uv-ci.yml
+++ b/.github/workflows/python-uv-ci.yml
@@ -1,7 +1,7 @@
 on:
   workflow_call:
     inputs:
-      runner:
+      runs-on:
         required: false
         type: string
         default: ubuntu-latest
@@ -121,7 +121,7 @@ on:
 
 jobs:
   python-ci:
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runs-on }}
 
     defaults:
       run:

--- a/.github/workflows/zendesk_github_add_comment.yml
+++ b/.github/workflows/zendesk_github_add_comment.yml
@@ -1,12 +1,17 @@
 name: Add comment to GitHub issue
 on:
   workflow_call:
+    inputs:
+      runner:
+        required: false
+        type: string
+        default: ubuntu-latest
 permissions:
   issues: write
 jobs:
   add-comment:
     name: Add comment to issue
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:

--- a/.github/workflows/zendesk_github_add_comment.yml
+++ b/.github/workflows/zendesk_github_add_comment.yml
@@ -2,7 +2,7 @@ name: Add comment to GitHub issue
 on:
   workflow_call:
     inputs:
-      runner:
+      runs-on:
         required: false
         type: string
         default: ubuntu-latest
@@ -11,7 +11,7 @@ permissions:
 jobs:
   add-comment:
     name: Add comment to issue
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runs-on }}
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:

--- a/.github/workflows/zendesk_github_close_issue.yml
+++ b/.github/workflows/zendesk_github_close_issue.yml
@@ -2,7 +2,7 @@ name: Close GitHub issue
 on:
   workflow_call:
     inputs:
-      runner:
+      runs-on:
         required: false
         type: string
         default: ubuntu-latest
@@ -11,7 +11,7 @@ permissions:
 jobs:
   close_issue:
     name: Close GitHub issue
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runs-on }}
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:

--- a/.github/workflows/zendesk_github_close_issue.yml
+++ b/.github/workflows/zendesk_github_close_issue.yml
@@ -1,12 +1,17 @@
 name: Close GitHub issue
 on:
   workflow_call:
+    inputs:
+      runner:
+        required: false
+        type: string
+        default: ubuntu-latest
 permissions:
   issues: write
 jobs:
   close_issue:
     name: Close GitHub issue
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:


### PR DESCRIPTION
Adds an optional `runs-on` input to reusable GitHub Actions workflows so callers can override the job runner instead of being locked to `ubuntu-latest`.

- Preserve existing behavior by defaulting `runs-on` to `ubuntu-latest`
- Update Node, Python, Zendesk, publishing, deployment, and SHA-pinning reusable workflows to use the `runs-on` input
- Keep event-only workflows on their existing hard-coded runners
- Use an explicit `ubuntu-latest` fallback in the mixed-trigger SHA-pinning workflow for push/PR runs

Validation:
- Parsed all workflow YAML files successfully
- LSP diagnostics reported 0 errors for `.github/workflows`
- Confirmed `actionlint` is not installed locally, so that check could not be run

Breaking changes: none expected for existing callers.