### PR TITLE
feat: add optional version input to node-trusted-publish

### DIFF
--- a/.github/workflows/node-trusted-publish.yml
+++ b/.github/workflows/node-trusted-publish.yml
@@ -25,6 +25,14 @@ on:
         required: false
         type: string
         default: ''
+      version:
+        required: false
+        type: string
+        default: ''
+        # When set, the package version is overridden before publishing (via
+        # `npm version --no-git-tag-version`). Useful for prereleases whose
+        # version is computed at publish time rather than committed, e.g.
+        # `1.0.0-beta.42`. Leave empty to publish the committed version.
 
 jobs:
   node-publish:
@@ -64,6 +72,10 @@ jobs:
       - run: npm ci --ignore-scripts
 
       - run: npm run prepare --if-present
+
+      - name: Override version
+        if: ${{ inputs.version != '' }}
+        run: npm version "${{ inputs.version }}" --no-git-tag-version --allow-same-version
 
       - run: npm run build
 


### PR DESCRIPTION
## What

Adds an optional `version` input to the reusable `node-trusted-publish.yml` workflow. When set, the package version is overridden before build/publish via `npm version <version> --no-git-tag-version --allow-same-version`.

## Why

Enables **prerelease/beta publishing** where the version is computed by the caller at publish time (e.g. `1.0.0-beta.42`) rather than committed to the repo. Callers can pass a computed prerelease version plus `tag: beta` to publish a beta from an ordinary merge, without polluting the repo history with prerelease version bumps.

## Compatibility

Fully backward compatible — the input defaults to `''`, in which case the committed version is published exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)