### PR TITLE
feat(ci): add node-makerx-npm-trusted-publish workflow

### DIFF
--- a/.github/workflows/node-makerx-npm-trusted-publish.yml
+++ b/.github/workflows/node-makerx-npm-trusted-publish.yml
@@ -1,0 +1,115 @@
+# Publishes a pre-built package to npm.makerx.tech using GitHub Actions OIDC.
+#
+# Caller requirements:
+# - Commit the final package.json and package contents; this workflow does not
+#   install dependencies or build the package.
+# - Trigger only on pushes to main. Do not expose workflow_dispatch or inputs
+#   that allow another ref to be selected.
+# - Grant the called job `contents: read` and `id-token: write` permissions.
+# - Ensure the caller's workflow filename is on the registry allow-list.
+#
+# Publishing behavior:
+# - Authentication uses a short-lived OIDC token; no secrets are required.
+# - Published versions are immutable. Publishing an existing version fails.
+#
+# See MakerXStudio/npm-trusted-access docs/publishing.md for registry rules.
+# For publishing to npmjs.com, use node-trusted-publish.yml instead.
+
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        required: false
+        type: string
+        default: ubuntu-latest
+      node-version:
+        required: false
+        type: string
+        default: 24.x
+      working-directory:
+        description: Directory containing the package.json to publish
+        required: false
+        type: string
+        default: "."
+      registry-url:
+        required: false
+        type: string
+        default: "https://npm.makerx.tech/"
+      dist-tag:
+        description: Optional dist-tag; required by npm for prerelease versions
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  node-publish-trusted-access:
+    runs-on: ${{ inputs.runs-on }}
+    permissions:
+      contents: read
+      id-token: write # Required to mint the OIDC token
+
+    defaults:
+      run:
+        shell: bash
+        working-directory: ${{ inputs.working-directory }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Use Node.js ${{ inputs.node-version }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      # Mint, check and publish in one step so the ~5 minute token cannot
+      # expire between minting and use.
+      - name: Publish
+        env:
+          REGISTRY_URL: ${{ inputs.registry-url }}
+          DIST_TAG: ${{ inputs.dist-tag }}
+        run: |
+          set -euo pipefail
+
+          AUDIENCE="${REGISTRY_URL%/}"
+          HOST="${AUDIENCE#https://}"
+
+          NAME=$(node -p "require('./package.json').name")
+          VERSION=$(node -p "require('./package.json').version")
+          PUBLISH_CONFIG_REGISTRY=$(node -p "require('./package.json').publishConfig?.registry ?? ''")
+
+          # publishConfig.registry takes precedence over --registry at publish
+          # time; fail fast if it points somewhere the minted token cannot reach.
+          if [ -n "$PUBLISH_CONFIG_REGISTRY" ] && [ "${PUBLISH_CONFIG_REGISTRY%/}" != "$AUDIENCE" ]; then
+            echo "::error::publishConfig.registry ($PUBLISH_CONFIG_REGISTRY) does not match registry-url ($REGISTRY_URL)"
+            exit 1
+          fi
+
+          TOKEN=$(curl -sS --fail -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=$AUDIENCE" | jq -r .value)
+          if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+            echo "Failed to mint OIDC token" >&2
+            exit 1
+          fi
+          echo "::add-mask::$TOKEN"
+          printf '//%s/:_authToken=%s\n' "$HOST" "$TOKEN" > "$RUNNER_TEMP/npm-trusted-access-publish.npmrc"
+          export NPM_CONFIG_USERCONFIG="$RUNNER_TEMP/npm-trusted-access-publish.npmrc"
+
+          # Denied reads and missing versions both return 404, but a publish
+          # grant implies a read grant on the same package, so a 404 here means
+          # the version genuinely is not published yet. A network failure is
+          # also swallowed here and surfaces on the publish below instead.
+          EXISTING=$(npm view "$NAME@$VERSION" version --registry "$REGISTRY_URL" 2>/dev/null || true)
+          if [ "$EXISTING" = "$VERSION" ]; then
+            echo "::error::$NAME@$VERSION is already published."
+            exit 1
+          fi
+
+          if [ -n "$DIST_TAG" ]; then
+            npm publish --ignore-scripts --registry "$REGISTRY_URL" --tag "$DIST_TAG"
+          else
+            npm publish --ignore-scripts --registry "$REGISTRY_URL"
+          fi
+          echo "::notice::Published $NAME@$VERSION to $REGISTRY_URL"

--- a/.github/workflows/node-makerx-npm-trusted-publish.yml
+++ b/.github/workflows/node-makerx-npm-trusted-publish.yml
@@ -17,10 +17,6 @@ on:
         required: false
         type: string
         default: "."
-      registry-url:
-        required: false
-        type: string
-        default: "https://npm.makerx.tech/"
       dist-tag:
         description: Optional dist-tag; required by npm for prerelease versions
         required: false
@@ -54,7 +50,7 @@ jobs:
       # expire between minting and use.
       - name: Publish
         env:
-          REGISTRY_URL: ${{ inputs.registry-url }}
+          REGISTRY_URL: https://npm.makerx.tech/
           DIST_TAG: ${{ inputs.dist-tag }}
         run: |
           set -euo pipefail
@@ -69,7 +65,7 @@ jobs:
           # publishConfig.registry takes precedence over --registry at publish
           # time; fail fast if it points somewhere the minted token cannot reach.
           if [ -n "$PUBLISH_CONFIG_REGISTRY" ] && [ "${PUBLISH_CONFIG_REGISTRY%/}" != "$AUDIENCE" ]; then
-            echo "::error::publishConfig.registry ($PUBLISH_CONFIG_REGISTRY) does not match registry-url ($REGISTRY_URL)"
+            echo "::error::publishConfig.registry ($PUBLISH_CONFIG_REGISTRY) does not match the publish registry ($REGISTRY_URL)"
             exit 1
           fi
 

--- a/.github/workflows/node-makerx-npm-trusted-publish.yml
+++ b/.github/workflows/node-makerx-npm-trusted-publish.yml
@@ -1,18 +1,4 @@
 # Publishes a pre-built package to npm.makerx.tech using GitHub Actions OIDC.
-#
-# Caller requirements:
-# - Commit the final package.json and package contents; this workflow does not
-#   install dependencies or build the package.
-# - Trigger only on pushes to main. Do not expose workflow_dispatch or inputs
-#   that allow another ref to be selected.
-# - Grant the called job `contents: read` and `id-token: write` permissions.
-# - Ensure the caller's workflow filename is on the registry allow-list.
-#
-# Publishing behavior:
-# - Authentication uses a short-lived OIDC token; no secrets are required.
-# - Published versions are immutable. Publishing an existing version fails.
-#
-# See MakerXStudio/npm-trusted-access docs/publishing.md for registry rules.
 # For publishing to npmjs.com, use node-trusted-publish.yml instead.
 
 on:


### PR DESCRIPTION
Adds a reusable workflow that publishes a pre-built package to `npm.makerx.tech` using GitHub Actions OIDC, so consuming repos no longer need a long-lived registry token.

- New `.github/workflows/node-makerx-npm-trusted-publish.yml`, callable via `workflow_call` with `runs-on`, `node-version`, `working-directory` and `dist-tag` inputs. The registry URL is hardcoded to `https://npm.makerx.tech/` and cannot be overridden by callers.
- Mints the OIDC token, checks the version, and publishes in a single step, because the minted token is only valid for roughly five minutes.
- Validates `publishConfig.registry` against the publish registry before publishing. `publishConfig.registry` takes precedence at publish time, so a mismatch would otherwise send the package to a registry the minted token cannot reach.
- Fails with a clear message when the version is already published, rather than surfacing a raw registry error. Published versions are immutable.
- Masks the minted token, writes it to a temp `.npmrc` under `RUNNER_TEMP`, checks out with `persist-credentials: false`, and publishes with `--ignore-scripts`.

## Notes for reviewers

- This workflow does not install dependencies or build. Callers commit the final `package.json` and package contents. That is the main difference from `node-trusted-publish.yml`, which targets npmjs.com and builds the package itself.
- Caller requirements: trigger only on pushes to `main`, do not expose `workflow_dispatch` or any input that selects another ref, grant the called job `contents: read` and `id-token: write`, and make sure the caller's workflow filename is on the registry allow-list. See `docs/publishing.md` in `MakerXStudio/npm-trusted-access` for the registry rules.
- Actions are SHA-pinned with full version comments, matching the `ensure-sha-pinned-actions` check.
- `feat` means Release Please will cut a minor release for this.
